### PR TITLE
AppOpenResult refactoring

### DIFF
--- a/demo/src/main/java/dk/nodes/nstack/demo/Application.kt
+++ b/demo/src/main/java/dk/nodes/nstack/demo/Application.kt
@@ -3,7 +3,7 @@ package dk.nodes.nstack.demo
 import android.app.Application
 import android.util.Log
 import dk.nodes.nstack.kotlin.NStack
-import dk.nodes.nstack.kotlin.models.AppOpenResult
+import dk.nodes.nstack.kotlin.models.Result
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
@@ -23,16 +23,9 @@ class Application : Application() {
 
         GlobalScope.launch {
             withContext(Dispatchers.IO) {
-                when (val result: AppOpenResult = NStack.appOpen()) {
-                    is AppOpenResult.Success -> {
-                        Log.d("AppOpenResult", result.toString())
-                    }
-                    is AppOpenResult.Failure -> {
-                        Log.d("AppOpenResult", "Failure")
-                    }
-                    is AppOpenResult.NoInternet -> {
-                        Log.d("AppOpenResult", "NoInternet")
-                    }
+                when (val result = NStack.appOpen()) {
+                    is Result.Success ->  Log.d("AppOpenResult: Success", result.toString())
+                    is Result.Error -> Log.d("AppOpenResult: Error", result.toString())
                 }
             }
         }

--- a/nstack-kotlin-core/src/main/java/dk/nodes/nstack/kotlin/managers/NetworkManager.kt
+++ b/nstack-kotlin-core/src/main/java/dk/nodes/nstack/kotlin/managers/NetworkManager.kt
@@ -2,30 +2,29 @@ package dk.nodes.nstack.kotlin.managers
 
 import com.google.gson.JsonObject
 import com.google.gson.reflect.TypeToken
-import dk.nodes.nstack.kotlin.models.AppOpenResult
 import dk.nodes.nstack.kotlin.models.AppOpenSettings
-import dk.nodes.nstack.kotlin.models.AppUpdateData
-import dk.nodes.nstack.kotlin.models.AppUpdateResponse
+import dk.nodes.nstack.kotlin.models.AppOpenData
+import dk.nodes.nstack.kotlin.models.AppOpen
 import dk.nodes.nstack.kotlin.models.Empty
 import dk.nodes.nstack.kotlin.models.Error
 import dk.nodes.nstack.kotlin.models.Feedback
 import dk.nodes.nstack.kotlin.models.Proposal
 import dk.nodes.nstack.kotlin.models.RateReminder2
+import dk.nodes.nstack.kotlin.models.Result
 import dk.nodes.nstack.kotlin.models.TermDetailsResponse
 import dk.nodes.nstack.kotlin.models.TermsDetails
 import dk.nodes.nstack.kotlin.provider.GsonProvider
-import dk.nodes.nstack.kotlin.models.Result
 import dk.nodes.nstack.kotlin.util.DateDeserializer.Companion.DATE_FORMAT
-import java.io.IOException
-import java.text.SimpleDateFormat
-import java.util.Date
-import java.util.Locale
 import okhttp3.Call
 import okhttp3.Callback
 import okhttp3.FormBody
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
+import java.io.IOException
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
 
 class NetworkManager(
     private val client: OkHttpClient,
@@ -70,7 +69,7 @@ class NetworkManager(
     fun postAppOpen(
         settings: AppOpenSettings,
         acceptLanguage: String,
-        onSuccess: (AppUpdateData) -> Unit,
+        onSuccess: (AppOpenData) -> Unit,
         onError: (Exception) -> Unit
     ) {
         FormBody.Builder().also {
@@ -92,7 +91,7 @@ class NetworkManager(
             override fun onResponse(call: Call?, response: Response?) {
                 try {
                     val responseString = response?.body()?.string()!!
-                    val appUpdate = gson.fromJson(responseString, AppUpdateResponse::class.java)
+                    val appUpdate = gson.fromJson(responseString, AppOpen::class.java)
                     onSuccess.invoke(appUpdate.data)
                 } catch (e: Exception) {
                     onError(e)
@@ -101,25 +100,29 @@ class NetworkManager(
         })
     }
 
-    suspend fun postAppOpen(settings: AppOpenSettings, acceptLanguage: String): AppOpenResult =
-        try {
-            FormBody.Builder().also {
-                it["guid"] = settings.guid
-                it["version"] = settings.version
-                it["old_version"] = settings.oldVersion
-                it["platform"] = settings.platform
-                it["last_updated"] = settings.lastUpdated.formatted
-                it["dev"] = debugMode.toString()
-                it["test"] = settings.versionUpdateTestMode.toString()
-            }.buildRequest(
-                "$baseUrl/api/v2/open",
-                "Accept-Language" to acceptLanguage
-            ).execute().body()?.string()?.let {
-                AppOpenResult.Success(gson.fromJson(it, AppUpdateResponse::class.java))
-            } ?: AppOpenResult.Failure
-        } catch (e: Exception) {
-            AppOpenResult.Failure
-        }
+    suspend fun postAppOpen(
+        settings: AppOpenSettings,
+        acceptLanguage: String
+    ): Result<AppOpen> = try {
+        FormBody.Builder().also {
+            it["guid"] = settings.guid
+            it["version"] = settings.version
+            it["old_version"] = settings.oldVersion
+            it["platform"] = settings.platform
+            it["last_updated"] = settings.lastUpdated.formatted
+            it["dev"] = debugMode.toString()
+            it["test"] = settings.versionUpdateTestMode.toString()
+        }.buildRequest(
+            "$baseUrl/api/v2/open",
+            "Accept-Language" to acceptLanguage
+        ).execute().body()?.string()?.let {
+            Result.Success(gson.fromJson(it, AppOpen::class.java))
+        } ?: Result.Error(Error.UnknownError)
+    } catch (e: IOException) {
+        Result.Error(Error.NetworkError)
+    } catch (e: Exception) {
+        Result.Error(Error.UnknownError)
+    }
 
     /**
      * Notifies the backend that the message has been seen

--- a/nstack-kotlin-core/src/main/java/dk/nodes/nstack/kotlin/models/AppOpen.kt
+++ b/nstack-kotlin-core/src/main/java/dk/nodes/nstack/kotlin/models/AppOpen.kt
@@ -1,0 +1,12 @@
+package dk.nodes.nstack.kotlin.models
+
+/**
+ * Holds all NStack features related data relevant for app start.
+ *
+ * @see [AppOpenData]
+ * @see [AppOpenMeta]
+ */
+data class AppOpen(
+    val data: AppOpenData,
+    val meta: AppOpenMeta
+)

--- a/nstack-kotlin-core/src/main/java/dk/nodes/nstack/kotlin/models/AppOpenData.kt
+++ b/nstack-kotlin-core/src/main/java/dk/nodes/nstack/kotlin/models/AppOpenData.kt
@@ -2,7 +2,7 @@ package dk.nodes.nstack.kotlin.models
 
 import java.util.Date
 
-data class AppUpdateData(
+data class AppOpenData(
     val count: Int = 0,
     val update: AppUpdate = AppUpdate(),
     val localize: List<LocalizeIndex> = listOf(),

--- a/nstack-kotlin-core/src/main/java/dk/nodes/nstack/kotlin/models/AppOpenMeta.kt
+++ b/nstack-kotlin-core/src/main/java/dk/nodes/nstack/kotlin/models/AppOpenMeta.kt
@@ -1,5 +1,5 @@
 package dk.nodes.nstack.kotlin.models
 
-data class AppUpdateMeta(
+data class AppOpenMeta(
     val acceptLanguage: String?
 )

--- a/nstack-kotlin-core/src/main/java/dk/nodes/nstack/kotlin/models/AppOpenResult.kt
+++ b/nstack-kotlin-core/src/main/java/dk/nodes/nstack/kotlin/models/AppOpenResult.kt
@@ -1,7 +1,0 @@
-package dk.nodes.nstack.kotlin.models
-
-sealed class AppOpenResult {
-    data class Success(val appUpdateResponse: AppUpdateResponse) : AppOpenResult()
-    object NoInternet : AppOpenResult()
-    object Failure : AppOpenResult()
-}

--- a/nstack-kotlin-core/src/main/java/dk/nodes/nstack/kotlin/models/AppUpdateResponse.kt
+++ b/nstack-kotlin-core/src/main/java/dk/nodes/nstack/kotlin/models/AppUpdateResponse.kt
@@ -1,6 +1,0 @@
-package dk.nodes.nstack.kotlin.models
-
-data class AppUpdateResponse(
-    val data: AppUpdateData,
-    val meta: AppUpdateMeta
-)


### PR DESCRIPTION
- Use generic Result and Error classes
- Fix/Update App Open related tests
- Rename 'AppUpdate' to 'AppOpen'
- Guard connectivity in Terms