### PR TITLE
Fixed locale bug: Locals would be generated using only the language-c…

### DIFF
--- a/app/src/main/java/dk/nodes/nstack/kotlin/models/Language.kt
+++ b/app/src/main/java/dk/nodes/nstack/kotlin/models/Language.kt
@@ -15,7 +15,16 @@ data class Language(
     constructor(jsonObject: JSONObject) : this(
         id = jsonObject.getInt("id"),
         name = jsonObject.getString("name"),
-        locale = Locale(jsonObject.getString("locale")),
+        locale = try { // Locale.forLanguageTag() would be better
+            Locale(
+                jsonObject.getString("locale").split("-|_").first(),
+                jsonObject.getString("locale").split("-|_").last()
+            )
+        } catch (e : NullPointerException) {
+            Locale(
+                    jsonObject.getString("locale")
+            )
+        },
         direction = jsonObject.getString("direction"),
         isDefault = jsonObject.getBoolean("is_default"),
         isBestFit = jsonObject.getBoolean("is_best_fit")


### PR DESCRIPTION
…onstructor, not the language+country-constructor
Locales are a combination of a language and a country and (optionally variant)

"en"-"GB" is a Locale
"en-gb"-"" is not